### PR TITLE
extend invoices api

### DIFF
--- a/djstripe/contrib/rest_framework/serializers.py
+++ b/djstripe/contrib/rest_framework/serializers.py
@@ -10,7 +10,7 @@
 from __future__ import unicode_literals
 
 from rest_framework.serializers import ModelSerializer
-from djstripe.models import CurrentSubscription, Invoice, Charge
+from djstripe.models import CurrentSubscription, Invoice, InvoiceItem, Charge
 from rest_framework import serializers
 
 
@@ -29,6 +29,11 @@ class CreateSubscriptionSerializer(serializers.Serializer):
 class InvoiceSerializer(serializers.ModelSerializer):
     class Meta:
         model = Invoice
+
+
+class InvoiceItemSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = InvoiceItem
 
 
 class ChargeSerializer(serializers.ModelSerializer):

--- a/djstripe/contrib/rest_framework/serializers.py
+++ b/djstripe/contrib/rest_framework/serializers.py
@@ -12,6 +12,7 @@ from __future__ import unicode_literals
 from rest_framework.serializers import ModelSerializer
 from djstripe.models import CurrentSubscription, Invoice, InvoiceItem, Charge
 from rest_framework import serializers
+import stripe
 
 
 class SubscriptionSerializer(ModelSerializer):
@@ -28,6 +29,9 @@ class CreateSubscriptionSerializer(serializers.Serializer):
 
 class InvoiceSerializer(serializers.ModelSerializer):
 
+    """
+        High-level metadata
+    """
     card_info = serializers.SerializerMethodField()
     plan = serializers.SerializerMethodField()
 
@@ -48,8 +52,40 @@ class InvoiceSerializer(serializers.ModelSerializer):
 
 
 class InvoiceItemSerializer(serializers.ModelSerializer):
+
+    """
+        Line-item details for an invoice
+    """
     class Meta:
         model = InvoiceItem
+
+
+class InvoiceDetailSerializer(serializers.Serializer):
+    """
+        Invoice details required for client-side invoice doc data
+    """
+
+    stripe_id = serializers.CharField(max_length=200, required=False)
+    total = serializers.SerializerMethodField()
+    line_items = serializers.SerializerMethodField()
+    billing_info = serializers.SerializerMethodField()
+
+    def get_total(self, instance):
+        return instance.total
+
+    def get_line_items(self, instance):
+        invoices = InvoiceItem.objects.filter(invoice_id=instance.id).order_by('created')
+        return [InvoiceItemSerializer(invoice).data for invoice in invoices]
+
+    def get_billing_info(self, instance):
+        charge = Charge.objects.get(stripe_id=instance.charge) # abbreviated django model
+        charge_details = stripe.Charge.retrieve(charge.stripe_id) # need address details from Stripe API
+        return {
+            "period_start": instance.period_start,
+            "period_end": instance.period_end,
+            "card": {"kind": charge_details.card.brand, "last4": charge_details.card.last4},
+            "address": {address: value for (address, value) in charge_details.card.items() if "address" in address}
+        }
 
 
 class ChargeSerializer(serializers.ModelSerializer):

--- a/djstripe/contrib/rest_framework/serializers.py
+++ b/djstripe/contrib/rest_framework/serializers.py
@@ -27,8 +27,24 @@ class CreateSubscriptionSerializer(serializers.Serializer):
 
 
 class InvoiceSerializer(serializers.ModelSerializer):
+
+    card_info = serializers.SerializerMethodField()
+    plan = serializers.SerializerMethodField()
+
     class Meta:
         model = Invoice
+
+    def get_card_info(self, instance):
+        charge = Charge.objects.get(stripe_id=instance.charge)
+        card_info = {
+          "kind": charge.card_kind,
+          "last4": charge.card_last_4
+        }
+        return card_info
+
+    def get_plan(self, instance):
+        inv_item_plan = instance.items.get(plan__isnull=False)
+        return inv_item_plan.plan
 
 
 class InvoiceItemSerializer(serializers.ModelSerializer):

--- a/djstripe/contrib/rest_framework/urls.py
+++ b/djstripe/contrib/rest_framework/urls.py
@@ -42,7 +42,7 @@ urlpatterns = [
     ),
     url(
         r"^invoices/(?P<invoice_id>\w+)/$",
-        views.InvoiceItemRestView.as_view(),
+        views.InvoiceItemsRestView.as_view(),
         name="invoice-item"
     ),
     url(

--- a/djstripe/contrib/rest_framework/urls.py
+++ b/djstripe/contrib/rest_framework/urls.py
@@ -41,6 +41,11 @@ urlpatterns = [
         name="invoice"
     ),
     url(
+        r"^invoices/(?P<stripe_id>\w+)/$",
+        views.InvoiceItemRestView.as_view(),
+        name="invoice-item"
+    ),
+    url(
         r"^charges/$",
         views.ChargeRestView.as_view(),
         name="charge"

--- a/djstripe/contrib/rest_framework/urls.py
+++ b/djstripe/contrib/rest_framework/urls.py
@@ -46,6 +46,11 @@ urlpatterns = [
         name="invoice-item"
     ),
     url(
+        r"^billing-info/$",
+        views.BillingInfoRestView.as_view(),
+        name="billing-info"
+    ),
+    url(
         r"^charges/$",
         views.ChargeRestView.as_view(),
         name="charge"

--- a/djstripe/contrib/rest_framework/urls.py
+++ b/djstripe/contrib/rest_framework/urls.py
@@ -41,7 +41,7 @@ urlpatterns = [
         name="invoice"
     ),
     url(
-        r"^invoices/(?P<stripe_id>\w+)/$",
+        r"^invoices/(?P<invoice_id>\w+)/$",
         views.InvoiceItemRestView.as_view(),
         name="invoice-item"
     ),

--- a/djstripe/contrib/rest_framework/views.py
+++ b/djstripe/contrib/rest_framework/views.py
@@ -139,8 +139,8 @@ class InvoiceItemRestView(generics.ListAPIView):
     serializer_class = InvoiceItemSerializer
 
     def get_queryset(self, *args, **kwargs):
-        stripe_id = self.request._request.path[19:-1]
-        return InvoiceItem.objects.filter(stripe_id=stripe_id).order_by('created')
+        invoice_id = self.request._request.path[19:-1]
+        return InvoiceItem.objects.filter(invoice_id=invoice_id).order_by('created')
 
 
 class ChargeRestView(generics.ListAPIView):

--- a/djstripe/contrib/rest_framework/views.py
+++ b/djstripe/contrib/rest_framework/views.py
@@ -136,7 +136,7 @@ class BillingInfoRestView(APIView):
         # Use stripe api to pull identifiable billing address info
         stripe_customer = stripe.Customer.retrieve(customer.stripe_id)
 
-        return JsonResponse({"active_card": stripe_customer.active_card})
+        return JsonResponse({"active_card": stripe_customer.get('active_card')})
 
 
 class InvoiceRestView(generics.ListAPIView):

--- a/djstripe/contrib/rest_framework/views.py
+++ b/djstripe/contrib/rest_framework/views.py
@@ -20,9 +20,9 @@ from rest_framework import status, generics
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.views import APIView
 
-from djstripe.models import Invoice
+from djstripe.models import (Invoice, InvoiceItem)
 from djstripe.contrib.rest_framework.serializers import (
-        InvoiceSerializer, ChargeSerializer)
+        InvoiceSerializer, InvoiceItemSerializer, ChargeSerializer)
 
 from ...settings import subscriber_request_callback, CANCELLATION_AT_PERIOD_END
 from ...models import Customer, Plan
@@ -131,6 +131,16 @@ class InvoiceRestView(generics.ListAPIView):
             subscriber=subscriber_request_callback(self.request)
         )
         return Invoice.objects.filter(customer=customer).order_by('created')
+
+
+class InvoiceItemRestView(generics.ListAPIView):
+
+    permission_classes = (IsAuthenticated,)
+    serializer_class = InvoiceItemSerializer
+
+    def get_queryset(self, *args, **kwargs):
+        stripe_id = self.request._request.path[19:-1]
+        return InvoiceItem.objects.filter(stripe_id=stripe_id).order_by('created')
 
 
 class ChargeRestView(generics.ListAPIView):

--- a/djstripe/contrib/rest_framework/views.py
+++ b/djstripe/contrib/rest_framework/views.py
@@ -131,7 +131,8 @@ class InvoiceRestView(generics.ListAPIView):
             subscriber=subscriber_request_callback(self.request)
         )
         # note: autopaginate by limiting to 12 latest invoices (past year only)
-        return Invoice.objects.filter(customer=customer).order_by('created')
+        # todo: paginate results given a cursor parameter see https://stripe.com/docs/api#list_invoices
+        return Invoice.objects.filter(customer=customer).order_by('created')[:12]
 
 
 class InvoiceItemsRestView(generics.ListAPIView):


### PR DESCRIPTION
allow clients to query all invoice items associated with an individual invoice's stripe_id.

i.e. /-/stripe/invoices/in_1BwhMsdg2eg5q