### PR TITLE
hotfix: allow free user to update pre-existing card info

### DIFF
--- a/djstripe/contrib/rest_framework/views.py
+++ b/djstripe/contrib/rest_framework/views.py
@@ -178,7 +178,7 @@ class ChargeRestView(generics.ListAPIView):
 
 
 class ChangeCreditCardRestView(APIView):
-    permission_classes = (IsAuthenticated, DJStripeSubscriptionPermission)
+    permission_classes = (IsAuthenticated,)
 
     def post(self, request):
         customer, created = Customer.get_or_create(


### PR DESCRIPTION
permit Free users to update their pre-existing billing info (on file from past Professional plan subscriptions)

blocks generate repo [PR 1579](https://github.com/frustumInc/cloudmesh-web-beta/pull/1579)